### PR TITLE
fix: remove unnecessary height of emojis

### DIFF
--- a/src/components/Chat/Markup/Emoji.css
+++ b/src/components/Chat/Markup/Emoji.css
@@ -9,6 +9,6 @@
 
 .Emoji-img {
   max-width: 100%;
-  max-height: 100%;
+  max-height: 10em;
   vertical-align: middle;
 }

--- a/src/components/Chat/Markup/Emoji.css
+++ b/src/components/Chat/Markup/Emoji.css
@@ -1,6 +1,5 @@
 .Emoji {
   /* Same size as the surrounding text */
-  height: 10em;
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;


### PR DESCRIPTION
Emojis that were too small were showed weirdly where the emoji
was at the beggining and there is an excessive amount of blankspace below.